### PR TITLE
use Ruamel's YAML library and add command-line flags, and more

### DIFF
--- a/src/main/python/yamlreader/__init__.py
+++ b/src/main/python/yamlreader/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import print_function, absolute_import, unicode_literals, division
 
-from .yamlreader import data_merge, yaml_load, YamlReaderError
+from .yamlreader import data_merge, get_files, YamlReaderError
 
-__all__ = ['data_merge', 'yaml_load', 'YamlReaderError']
+__all__ = ['data_merge', 'YamlReaderError']

--- a/src/main/python/yamlreader/yamlreader.py
+++ b/src/main/python/yamlreader/yamlreader.py
@@ -5,6 +5,7 @@ from __future__ import print_function, absolute_import, unicode_literals, divisi
 __version__ = '3.1.0'
 
 import ruamel.yaml as yaml
+import json
 import glob
 import os
 import sys
@@ -124,6 +125,8 @@ def __main():
     parser.add_option('--log', dest='loglevel', action='store', default='INFO',
                       help="(DEBUG *%default WARNING ERROR CRITICAL)")
 
+    parser.add_option('-j', '--json', dest='json', action='store_true', default=False,
+                      help="output to JSON (true *%default)")
                       # CloudFormation can't handle anchors or aliases (sep '17)
     parser.add_option('-x', '--no-anchor', dest='no_anchor', action='store_true', default=False,
                       help="unroll anchors/aliases (true *%default)")
@@ -225,7 +228,10 @@ def __main():
         return 1
 
     try:
-        myaml.dump(data, sys.stdout)
+        if options.json:
+            json.dump(data, sys.stdout)
+        else:
+            myaml.dump(data, sys.stdout)
     except yaml.MarkedYAMLError as e:
         raise YamlReaderError('YAML.dump() -- %s' % str(e))
         #YamlReaderError("YAML.dump(): %s" % str(e))

--- a/src/main/python/yamlreader/yamlreader.py
+++ b/src/main/python/yamlreader/yamlreader.py
@@ -1,9 +1,10 @@
+#!env python3
+
 from __future__ import print_function, absolute_import, unicode_literals, division
 
 __version__ = '3.1.0'
 
 import ruamel.yaml as yaml
-from ruamel.yaml import MarkedYAMLError, safe_load, safe_dump
 import glob
 import os
 import sys

--- a/src/main/python/yamlreader/yamlreader.py
+++ b/src/main/python/yamlreader/yamlreader.py
@@ -64,32 +64,6 @@ def data_merge(a, b):
         else:
             raise TypeError
 
-#----- original
-        # if a is None or isinstance(a, (six.string_types, float, six.integer_types)):
-            # # border case for first run or if a is a primitive
-            # a = b
-        # elif isinstance(a, list):
-            # # lists can be only appended
-            # if isinstance(b, list):
-                # # merge lists
-                # a.extend(b)
-            # else:
-                # # append to list
-                # a.append(b)
-        # elif isinstance(a, dict):
-            # # dicts must be merged
-            # if isinstance(b, dict):
-                # for key in b:
-                    # if key in a:
-                        # a[key] = data_merge(a[key], b[key])
-                    # else:
-                        # a[key] = b[key]
-            # else:
-                # raise YamlReaderError('Illegal - %s into %s\n  "%s" -> "%s"' %
-                    # (type(b), type(a), b, a), logging.WARNING)
-        # else:
-            # raise YamlReaderError('TODO - %s into %s\n  "%s" -> "%s"' %
-                # (type(b), type(a), b, a), logging.WARNING)
     except (TypeError, LookupError) as e:
         raise YamlReaderError('caught %r merging %r into %r\n  "%s" -> "%s"' % 
             (e, type(b), type(a), b, a), logging.WARNING)

--- a/src/main/python/yamlreader/yamlreader.py
+++ b/src/main/python/yamlreader/yamlreader.py
@@ -28,7 +28,7 @@ class YamlReaderError(Exception):
         # try:
         super().__init__(msg)
         logger.log(level, '%s::%s', sys._getframe().f_back.f_code.co_name, msg,
-            exc_info=(logger.getEffectiveLevel() == logging.DEBUG), kwargs)
+            exc_info=(logger.getEffectiveLevel() == logging.DEBUG), **kwargs)
 
         if (level == logging.FATAL):
             sys.exit(1)
@@ -229,12 +229,15 @@ def __main():
 
     try:
         if options.json:
-            json.dump(data, sys.stdout)
+            json.dump(data, sys.stdout, indent=indent['mapping'])
         else:
             myaml.dump(data, sys.stdout)
     except yaml.MarkedYAMLError as e:
         raise YamlReaderError('YAML.dump() -- %s' % str(e))
         #YamlReaderError("YAML.dump(): %s" % str(e))
+    except (ValueError, OverflowError, TypeError):
+        # JSON dump might trigger
+        pass
 
         
 if __name__ == "__main__":


### PR DESCRIPTION
This amounts to a near total rewrite.
* multitude of command-line args
* use the Ruamel library which actually tracks the current spec and not an orphan
* split-out filepath expansion and data merging
* properly hook Logger in exceptions

crank version to 3.1